### PR TITLE
add one click deploy to netlify!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://reactql.org/reactql/logo.svg" alt="ReactQL" width="278" height="77" />
 
-![license](https://img.shields.io/github/license/leebenson/reactql.svg?style=flat-square) [![Twitter Follow](https://img.shields.io/twitter/follow/reactql.svg?style=social&label=Follow)](https://twitter.com/reactql)
+![license](https://img.shields.io/github/license/leebenson/reactql.svg?style=flat-square) [![Twitter Follow](https://img.shields.io/twitter/follow/reactql.svg?style=social&label=Follow)](https://twitter.com/reactql) 
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/leebenson/reactql)
 
 Universal front-end React + GraphQL starter kit, written in Typescript.
 


### PR DESCRIPTION
love this project! saw that you are supporting clientside with v3.5 `npm run static` - 

just helping to add a deploy to netlify button for one click deploy! (https://www.netlify.com/docs/deploy-button/) 

ideally for true "one click" you'd need a `netlify.toml` file - [docs here](https://www.netlify.com/docs/netlify-toml-reference/) - i can help you if you need help but basically just need to specify the build command you want.